### PR TITLE
Fix NPE when ejecting the portable storage

### DIFF
--- a/src/com/android/settings/deviceinfo/PublicVolumeSettings.java
+++ b/src/com/android/settings/deviceinfo/PublicVolumeSettings.java
@@ -129,6 +129,11 @@ public class PublicVolumeSettings extends SettingsPreferenceFragment {
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
+
+        if (!isVolumeValid()) {
+            return;
+        }
+
         final Resources resources = getResources();
         final int padding = resources.getDimensionPixelSize(
                 R.dimen.unmount_button_padding);


### PR DESCRIPTION
* In onCreate there's isVolumeValid check which
  won't let the mUnmount to be declared.
  Adding similar check to onActivityCreated fixes this NPE.

Change-Id: Ie7fcdee36bb09851ac1306f316436f7270342990